### PR TITLE
feat: Camera detached from player (#25)

### DIFF
--- a/game-core/src/state/game.rs
+++ b/game-core/src/state/game.rs
@@ -23,18 +23,17 @@ impl<'a, 'b> SimpleState<'a, 'b> for Game {
 mod init {
     use amethyst::utils::ortho_camera::CameraNormalizeMode;
     use amethyst::utils::ortho_camera::CameraOrtho;
-    use amethyst::{
-        core::{Parent, Transform},
-        ecs::Entity,
-        prelude::*,
-        renderer::Camera,
-    };
+    use amethyst::{core::Transform, ecs::Entity, prelude::*, renderer::Camera};
 
     pub fn camera(world: &mut World, parent: Entity) {
-        let mut transform = Transform::default();
+        let mut transform = {
+            let transforms = world.read_storage::<Transform>();
+            transforms.get(parent).unwrap().clone()
+        };
+
         transform.translation.z = 2.0;
-        transform.translation.x = -256.0;
-        transform.translation.y = -256.0;
+        transform.translation.x -= 256.0;
+        transform.translation.y -= 256.0;
         transform.scale.x = 512.0;
         transform.scale.y = 512.0;
 
@@ -44,7 +43,6 @@ mod init {
             .create_entity()
             .with(CameraOrtho::normalized(CameraNormalizeMode::Contain))
             .with(Camera::standard_2d())
-            .with(Parent { entity: parent })
             .with(transform)
             .build();
     }

--- a/game-core/src/system/camera.rs
+++ b/game-core/src/system/camera.rs
@@ -1,0 +1,39 @@
+use amethyst::core::cgmath::InnerSpace;
+use amethyst::core::cgmath::Vector2;
+use amethyst::renderer::Camera;
+use amethyst::{
+    core::Transform,
+    ecs::{Join, ReadStorage, System, WriteStorage},
+};
+use crate::component::Player;
+
+pub struct Movement;
+
+impl<'s> System<'s> for Movement {
+    type SystemData = (
+        ReadStorage<'s, Player>,
+        ReadStorage<'s, Camera>,
+        WriteStorage<'s, Transform>,
+    );
+
+    fn run(&mut self, (players, cameras, mut transforms): Self::SystemData) {
+        let mut player_translation = Vector2 { x: 0.0, y: 0.0 };
+
+        for (_, transform) in (&players, &mut transforms).join() {
+            player_translation = transform.translation.truncate();
+        }
+
+        for (_, transform) in (&cameras, &mut transforms).join() {
+            let camera_translation = transform.translation.truncate();
+            let camera_scale = transform.scale.truncate();
+            let player_direction = player_translation - camera_translation - camera_scale / 2.0;
+            let camera_safe_edge = camera_scale / 4.0;
+
+            if player_direction.magnitude2() > camera_safe_edge.magnitude2() {
+                let camera_shift =
+                    player_direction - player_direction.normalize_to(camera_safe_edge.magnitude());
+                transform.translation += camera_shift.extend(0.0);
+            }
+        }
+    }
+}

--- a/game-core/src/system/mod.rs
+++ b/game-core/src/system/mod.rs
@@ -1,4 +1,5 @@
 pub mod ally;
 pub mod animation;
+pub mod camera;
 pub mod enemy;
 pub mod player;

--- a/game-main/src/main.rs
+++ b/game-main/src/main.rs
@@ -11,7 +11,7 @@ use amethyst::{
     utils::application_root_dir,
 };
 use game_core::state::Game;
-use game_core::system::{ally, animation, enemy, player};
+use game_core::system::{ally, animation, camera, enemy, player};
 use std::env;
 
 fn main() -> amethyst::Result<()> {
@@ -40,6 +40,7 @@ fn main() -> amethyst::Result<()> {
                 .with_bindings_from_file(format!("{}/input.ron", root))?,
         )?.with(player::Movement, "player-movement", &[])
         .with(enemy::Movement, "enemy-movement", &[])
+        .with(camera::Movement, "camera-movement", &[])
         .with(enemy::Spawner, "enemy-spawner", &[])
         .with(ally::Movement, "ally-movement", &[])
         .with(ally::Grouper, "ally-grouper", &[])


### PR DESCRIPTION
Before this, the camera used the player as its Parent component, which would make the camera center on the player, but this caused some less than 100% desirable visual artifacts and made rotating the player character affect the camera.

This change decouples the player and the camera and adds a new system that updates the cameras position from the player. The rule of the update is that if the distance between the two positions becomes too great it will move the camera by the diff needed to change the distance back to the max distance. This change has the effect of causing the camera to be dragged along by the player character when it nears the edge of the screen.

This rule is probably not the best camera movement approach for a game that involves exploring new areas, but it's an acceptable first step. We can adjust it once we have other game elements in place.