### PR TITLE
Ally: added swarming (#31)

### DIFF
--- a/game-core/Cargo.toml
+++ b/game-core/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Jane Lusby <jlusby42@gmail.com>"]
 amethyst = "0.9.0"
 tiled = "0.8.0"
 rand = "0.6.0"
+serde = "1.0"

--- a/game-core/src/config.rs
+++ b/game-core/src/config.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Ally {
+    pub follow_distance: f32,
+    pub max_distance: f32,
+    pub min_distance: f32,
+}
+
+impl Default for Ally {
+    fn default() -> Self {
+        Ally {
+            follow_distance: 0.0,
+            max_distance: 0.0,
+            min_distance: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GameoffConfig {
+    pub ally: Ally,
+    pub speed: f32,
+}
+
+impl Default for GameoffConfig {
+    fn default() -> Self {
+        GameoffConfig {
+            speed: 0.0,
+            ally: Ally::default(),
+        }
+    }
+}

--- a/game-core/src/lib.rs
+++ b/game-core/src/lib.rs
@@ -4,8 +4,10 @@
 )]
 extern crate amethyst;
 extern crate rand;
+extern crate serde;
 
 mod component;
+pub mod config;
 mod load;
 mod map;
 mod state;
@@ -24,7 +26,8 @@ use state::Menu;
 
 pub fn run() -> amethyst::Result<()> {
     let root = format!("{}/resources", application_root_dir());
-    let config = DisplayConfig::load(format!("{}/display_config.ron", root));
+    let display_config = DisplayConfig::load(format!("{}/display_config.ron", root));
+    let gameoff_config = config::GameoffConfig::load(format!("{}/config.ron", root));
     let pipe = Pipeline::build().with_stage(
         Stage::with_backbuffer()
             .clear_target([0.1, 0.1, 0.1, 1.0], 1.0)
@@ -45,12 +48,14 @@ pub fn run() -> amethyst::Result<()> {
             "OrthoCamera",
             &[],
         ).with_bundle(
-            RenderBundle::new(pipe, Some(config))
+            RenderBundle::new(pipe, Some(display_config))
                 .with_sprite_sheet_processor()
                 .with_sprite_visibility_sorting(&[]), // Let's us use the `Transparent` component
         )?;
 
-    let mut game = Application::build(root, Menu)?.build(game_data)?;
+    let mut game = Application::build(root, Menu)?
+        .with_resource(gameoff_config)
+        .build(game_data)?;
     game.run();
     Ok(())
 }

--- a/game-core/src/state/menu.rs
+++ b/game-core/src/state/menu.rs
@@ -47,7 +47,7 @@ impl SimpleState<'static, 'static> for Menu {
             .with(ally::Spawner, "ally-spawner", &[])
             .with(player::Attack, "player-attack", &[])
             .with(animation::Frame, "frame-animation", &[])
-            .with(projectile::Movement, "projectile-movement", &[])
+            .with(motion::Movement, "projectile-movement", &[])
             .build();
         dispatcher.setup(&mut world.res);
         Trans::Push(Box::new(Game { dispatcher }))

--- a/game-core/src/system/mod.rs
+++ b/game-core/src/system/mod.rs
@@ -2,5 +2,5 @@ pub mod ally;
 pub mod animation;
 pub mod camera;
 pub mod enemy;
+pub mod motion;
 pub mod player;
-pub mod projectile;

--- a/game-core/src/system/motion.rs
+++ b/game-core/src/system/motion.rs
@@ -1,22 +1,21 @@
 use amethyst::{
     core::cgmath::{InnerSpace, Vector2},
     core::{timing::Time, Transform},
-    ecs::{Join, Read, ReadStorage, System, WriteStorage},
+    ecs::{Join, Read, System, WriteStorage},
 };
-use crate::component::{Motion, Projectile};
+use crate::component::Motion;
 
 pub struct Movement;
 
 impl<'s> System<'s> for Movement {
     type SystemData = (
-        ReadStorage<'s, Projectile>,
         WriteStorage<'s, Motion>,
         WriteStorage<'s, Transform>,
         Read<'s, Time>,
     );
 
-    fn run(&mut self, (projectiles, mut motions, mut transforms, time): Self::SystemData) {
-        for (_, motion, transform) in (&projectiles, &mut motions, &mut transforms).join() {
+    fn run(&mut self, (mut motions, mut transforms, time): Self::SystemData) {
+        for (motion, transform) in (&mut motions, &mut transforms).join() {
             let delta = time.delta_seconds();
             let distance = motion.vel * delta + 0.5 * motion.acc * delta.powf(2.0); // d = v*t + (a*t^2)/2
             if let Some(min_vel) = motion.min_vel {

--- a/game-main/resources/config.ron
+++ b/game-main/resources/config.ron
@@ -1,0 +1,8 @@
+(
+    ally: (
+      follow_distance : 30.0,
+      max_distance : 100.0,
+      min_distance : 10.0,
+    ),
+    speed : 20.0,
+)


### PR DESCRIPTION
Ally movement is now defined as trying to optimize the distance to
allies and the player. The allies do not like to be close to each other
and do not want to be too far from each other or the player.

A config file was added to aid in tuning.